### PR TITLE
Update parser.js

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -19,7 +19,7 @@
   defaults = require('./defaults').defaults;
 
   isEmpty = function(thing) {
-    return typeof thing === "object" && (thing != null) && Object.keys(thing).length === 0;
+    return typeof thing === Object && (thing != null) && Object.keys(thing).length === 0;
   };
 
   processItem = function(processors, item, key) {


### PR DESCRIPTION
Because of new ES6 syntax typeof thing is Object is not the same as typeof thing is 'Object' and the first one seem to work with a wider variety of object

